### PR TITLE
feat: add color model output options for export

### DIFF
--- a/src/app/screens/ExportScreen/ExportScreen.tsx
+++ b/src/app/screens/ExportScreen/ExportScreen.tsx
@@ -17,9 +17,9 @@ import Radio from '@mui/joy/Radio';
 import { NotifyMessage, FigmaMessage, MessageTypes } from 'declarations/messages';
 import { PLUGIN_ID } from 'declarations/plugin';
 import { CaseTypes, Case, CaseMap } from 'declarations/case';
-import { solidPaintToColor } from 'utils/color';
+import { colorToString, solidPaintToColor } from 'utils/color';
 import Tooltip from '@mui/material/Tooltip';
-import { getNativeSelectUtilityClasses } from '@mui/material';
+import { ColorModels, ColorModelType } from 'declarations/models';
 
 export function ExportScreen() {
   const theme = useTheme();
@@ -40,6 +40,8 @@ export function ExportScreen() {
     return CaseMap[languageOptions.supportedCaseStyles[0]];
   }, [caseType, languageOptions, setCaseType]);
 
+  const [model, setModel] = useState<ColorModelType>(ColorModels.RGB);
+
   const hasColorSelection = useMemo(() => selectedPaintStyles?.length > 0, [selectedPaintStyles?.length]);
 
   const styleObject = useMemo(() => {
@@ -47,12 +49,13 @@ export function ExportScreen() {
       const ps = style.paints[0];
 
       if (isSolidPaint(ps)) {
-        acc[caseFn(style.name)] = solidPaintToColor(ps).toString();
+        let result = colorToString(solidPaintToColor(ps), model);
+        acc[caseFn(style.name)] = result;
       }
 
       return acc;
     }, {});
-  }, [selectedPaintStyles, caseFn]);
+  }, [selectedPaintStyles, model, caseFn]);
 
   const compiledTemplate = useMemo(() => {
     if (typeof languageOptions?.templateFunction === 'function') {
@@ -145,6 +148,34 @@ export function ExportScreen() {
                   size="sm"
                   label={<Typography level="body3">{capitalCase(caseStyle)}</Typography>}
                 />
+              );
+            })}
+          </Box>
+        </RadioGroup>
+      </Box>
+
+      <Box sx={{ marginBottom: 2 }}>
+        <Typography level="body1" component="h1" fontWeight="bold" fontSize="12px" id="color-model">
+          Model
+        </Typography>
+
+        <RadioGroup
+          defaultValue={model}
+          value={model}
+          onChange={(event) => setModel(event.target.value as ColorModelType)}
+          aria-labelledby="color-model"
+          name="color-model"
+        >
+          <Box
+            display="grid"
+            gridTemplateColumns="1fr 1fr"
+            gap="5px"
+            marginTop={theme.spacing(1)}
+            marginBottom={theme.spacing(2)}
+          >
+            {Object.keys(ColorModels).map((model) => {
+              return (
+                <Radio key={model} value={model} size="sm" label={<Typography level="body3">{model}</Typography>} />
               );
             })}
           </Box>

--- a/src/declarations/languages.ts
+++ b/src/declarations/languages.ts
@@ -1,14 +1,3 @@
-import {
-  camelCase,
-  capitalCase,
-  constantCase,
-  dotCase,
-  headerCase,
-  paramCase,
-  pascalCase,
-  snakeCase,
-} from 'change-case';
-
 import Handlebars from 'handlebars';
 
 import TemplateCSS from 'templates/CSS.hbs';

--- a/src/declarations/models.ts
+++ b/src/declarations/models.ts
@@ -1,0 +1,7 @@
+export enum ColorModels {
+  RGB = 'RGB',
+  HSL = 'HSL',
+  HEX = 'HEX',
+}
+
+export type ColorModelType = `${ColorModels}`;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,5 @@
 import Color from 'color';
+import { ColorModels, ColorModelType } from 'declarations/models';
 
 export function solidPaintToColor(paint: SolidPaint): Color {
   const alpha = Number(typeof paint.opacity === 'number' ? paint.opacity : 1);
@@ -8,4 +9,22 @@ export function solidPaintToColor(paint: SolidPaint): Color {
     g: paint.color.g * 255,
     b: paint.color.b * 255,
   }).alpha(Number(alpha.toFixed(2)));
+}
+
+export function colorToString(color: Color, model: ColorModelType = ColorModels.RGB) {
+  switch (model) {
+    case 'HSL':
+      return color.hsl().string();
+    case 'RGB':
+      return color.rgb().string();
+    case 'HEX':
+      const hex = color.hexa();
+      if (hex.length === 9 && hex.substring(7, 9) === 'FF') {
+        return hex.substring(0, 7);
+      }
+
+      return hex;
+    default:
+      return color.toString();
+  }
 }


### PR DESCRIPTION
Add "Model" section to Export screen that allows user to select output color model. Either HEX, RGB, or HSL. 